### PR TITLE
Implement fine-grained directories for data volumes

### DIFF
--- a/Dockerfile-smoketests
+++ b/Dockerfile-smoketests
@@ -1,4 +1,4 @@
-# gwul/sfm-base:2.4.0.rc1
+# gwul/sfm-base:2.4.0
 FROM gwul/sfm-base@sha256:dc6f305631f756d9c25517b6322ec83a024c11c3e1e1d7be742d74a57b1f1028
 MAINTAINER Social Feed Manager <sfm@gwu.edu>
 

--- a/Dockerfile-smoketests
+++ b/Dockerfile-smoketests
@@ -1,4 +1,5 @@
-FROM gwul/sfm-base@sha256:bf84472ee4819b86a90a39c184f190b5ab769026eb427fe784625f3148490e55
+# gwul/sfm-base:2.4.0.rc1
+FROM gwul/sfm-base@sha256:dc6f305631f756d9c25517b6322ec83a024c11c3e1e1d7be742d74a57b1f1028
 MAINTAINER Social Feed Manager <sfm@gwu.edu>
 
 RUN apt-get update && apt-get install -y \

--- a/docker/data/setup_dirs.sh
+++ b/docker/data/setup_dirs.sh
@@ -2,21 +2,21 @@
 
 groupadd -r sfm --gid=$SFM_GID && useradd -r -g sfm --uid=$SFM_UID sfm
 
-export COLLECTION_SET_DIR=/sfm-data/collection_set
+export COLLECTION_SET_DIR=/sfm-collection-set-data/collection_set
 if [ ! -d $COLLECTION_SET_DIR ]; then
     echo "Creating collection_sets directory"
     mkdir -p $COLLECTION_SET_DIR
     chown sfm:sfm $COLLECTION_SET_DIR
 fi
 
-export CONTAINERS_DIR=/sfm-data/containers
+export CONTAINERS_DIR=/sfm-containers-data/containers
 if [ ! -d $CONTAINERS_DIR ]; then
     echo "Creating containers directory"
     mkdir -p $CONTAINERS_DIR
     chown sfm:sfm $CONTAINERS_DIR
 fi
 
-export EXPORT_DIR=/sfm-data/export
+export EXPORT_DIR=/sfm-export-data/export
 if [ ! -d $EXPORT_DIR ]; then
     echo "Creating export directory"
     mkdir -p $EXPORT_DIR

--- a/example.docker-compose.yml
+++ b/example.docker-compose.yml
@@ -40,6 +40,9 @@ services:
              - ${DATA_VOLUME_EXPORT}
              - ${DATA_VOLUME_CONTAINERS}
              - ${DATA_VOLUME_COLLECTION_SET}
+             # For SFM instances installed on 2.3.0 or earlier
+             # - ${DATA_VOLUME_FORMER_COLLECTION_SET
+             # - ${DATA_VOLUME_FORMER_EXPORT}
         environment:
             - TZ
             - SFM_UID

--- a/example.docker-compose.yml
+++ b/example.docker-compose.yml
@@ -95,7 +95,11 @@ services:
             # To have some test accounts created.
             - LOAD_FIXTURES=${LOAD_FIXTURES}
             - SFM_REQS=${UI_REQS}
-            - DATA_VOLUME_THRESHOLD
+            - DATA_VOLUME_THRESHOLD_DB
+            - DATA_VOLUME_THRESHOLD_MQ
+            - DATA_VOLUME_THRESHOLD_EXPORT
+            - DATA_VOLUME_THRESHOLD_CONTAINERS
+            - DATA_VOLUME_THRESHOLD_COLLECTION_SET
             - PROCESSING_VOLUME_THRESHOLD
             - SFM_UID
             - SFM_GID

--- a/example.docker-compose.yml
+++ b/example.docker-compose.yml
@@ -90,6 +90,8 @@ services:
             - SFM_POSTGRES_PASSWORD
             - SFM_POSTGRES_HOST
             - SFM_POSTGRES_PORT
+            - SFM_RABBITMQ_MANAGEMENT_PORT
+            - SFM_POSTGRES_PASSWORD
             # To have some test accounts created.
             - LOAD_FIXTURES=${LOAD_FIXTURES}
             - SFM_REQS=${UI_REQS}

--- a/example.docker-compose.yml
+++ b/example.docker-compose.yml
@@ -41,8 +41,8 @@ services:
              - ${DATA_VOLUME_CONTAINERS}
              - ${DATA_VOLUME_COLLECTION_SET}
              # For SFM instances installed on 2.3.0 or earlier
-             # - ${DATA_VOLUME_FORMER_COLLECTION_SET
-             # - ${DATA_VOLUME_FORMER_EXPORT}
+             #- ${DATA_VOLUME_FORMER_COLLECTION_SET}
+             #- ${DATA_VOLUME_FORMER_EXPORT}
         environment:
             - TZ
             - SFM_UID

--- a/example.docker-compose.yml
+++ b/example.docker-compose.yml
@@ -101,6 +101,9 @@ services:
             - DATA_VOLUME_THRESHOLD_CONTAINERS
             - DATA_VOLUME_THRESHOLD_COLLECTION_SET
             - PROCESSING_VOLUME_THRESHOLD
+            - DATA_SHARED_USED
+            - DATA_SHARED_DIR
+            - DATA_THRESHOLD_SHARED 
             - SFM_UID
             - SFM_GID
             - SFM_UPGRADE_REQS=${UPGRADE_REQS}
@@ -127,6 +130,8 @@ services:
             - data
             - processingdata
 #        volumes:
+#           #  Uncomment to use DATA_SHARED_DIR and monitor space usage when data on single filesystem
+#           #- "${DATA_SHARED_DIR}:/sfm-data-shared"
 #            - "../sfm-ui:/opt/sfm-ui"
 #            # To also link in a local sfm-utils, uncomment this and set UI_REQS to "dev" in .env
 #            - "../sfm-utils:/opt/sfm-utils"

--- a/example.docker-compose.yml
+++ b/example.docker-compose.yml
@@ -129,9 +129,10 @@ services:
         volumes_from:
             - data
             - processingdata
-#        volumes:
-#           #  Uncomment to use DATA_SHARED_DIR and monitor space usage when data on single filesystem
-#           #- "${DATA_SHARED_DIR}:/sfm-data-shared"
+        # Comment out volumes if SFM data is stored on mounted filesystems and DATA_SHARED_USED is False.
+        volumes:
+            - "${DATA_SHARED_DIR}:/sfm-data-shared"
+            # To link in local sfm-ui code, uncomment this 
 #            - "../sfm-ui:/opt/sfm-ui"
 #            # To also link in a local sfm-utils, uncomment this and set UI_REQS to "dev" in .env
 #            - "../sfm-utils:/opt/sfm-utils"

--- a/example.docker-compose.yml
+++ b/example.docker-compose.yml
@@ -3,7 +3,7 @@ services:
     db:
         image: gwul/sfm-ui-db:master
         environment:
-            - SFM_POSTGRES_PASSWORD
+            - POSTGRES_PASSWORD=${SFM_POSTGRES_PASSWORD}
             - TZ
         logging:
             driver: json-file

--- a/example.docker-compose.yml
+++ b/example.docker-compose.yml
@@ -35,7 +35,11 @@ services:
     data:
         image: gwul/sfm-data:master
         volumes:
-             - ${DATA_VOLUME}
+             - ${DATA_VOLUME_MQ}
+             - ${DATA_VOLUME_DB}
+             - ${DATA_VOLUME_EXPORT}
+             - ${DATA_VOLUME_CONTAINERS}
+             - ${DATA_VOLUME_COLLECTION_SET}
         environment:
             - TZ
             - SFM_UID

--- a/example.env
+++ b/example.env
@@ -21,21 +21,22 @@ COMPOSE_PROJECT_NAME=sfm
 # * all of harvested social media content is stored (internally used /sfm-collection-set-data, /sfm-containers-data, /sfm-export-data).
 # * the db files are located (internally used /sfm-db-data).
 
-# the MQ container uses its own local volume
+# Tthe MQ container uses its own local volume. Configure an external location for production.
 DATA_VOLUME_MQ=/sfm-mq-data
 
 # In the case a local database is used, its data is stored under the following docker volume
 # In case a remote database is used this could point to a mounted folder where the DB stores its data,
-# otherwise it will not be used
+# otherwise it will not be used. Configure an external location for production.
 DATA_VOLUME_DB=/sfm-db-data
 
-# sensitive export data can be stored locally or remotely on a server mounted using sshfs
+# Sensitive export data can be stored locally or remotely on a server mounted using sshfs
 DATA_VOLUME_EXPORT=/mnt/my-ssh-drive:/sfm-export-data
 
-# possibly sensitive data from harvesting containers can be stored remotely on a server mounted using sshfs
+# Possibly sensitive data from harvesting containers can be stored remotely on a server mounted using sshfs
 DATA_VOLUME_CONTAINERS=/mnt/my-ssh-drive:/sfm-containers-data
 
-# sensitive data about collection sets can be stored remotely on a server mounted using sshfs
+# Sensitive data about collection sets can be stored remotely on a server mounted using sshfs.
+# Configure an external location for production.
 DATA_VOLUME_COLLECTION_SET=/mnt/my-ssh-drive:/sfm-collection-set-data
 
 # The processing volume is where processed data is stored when using a processing
@@ -43,15 +44,16 @@ DATA_VOLUME_COLLECTION_SET=/mnt/my-ssh-drive:/sfm-collection-set-data
 PROCESSING_VOLUME=/sfm-processing
 #PROCESSING_VOLUME=/src/sfm-processing:/sfm-processing
 
-# If all data volumes are on the same filesystem (the default configuration before SFM 2.4.0) 
-# set DATA_SHARED_USED to True and uncomment and provide DATA_SHARED_DIR, which is used only for calculating space usage.
+# If all data volumes (does not include /sfm-processing) are on the same filesystem 
+# DATA_SHARED_USED should be True and provide DATA_SHARED_DIR, which is used only for calculating space usage.
+# If any volumes are on mounted filesystems, DATA_SHARED_USED should be False and comment out DATA_SHARED_DIR. 
 # The value of DATA_SHARED_DIR is the parent directory for data volumes, e.g. /sfm-data
-DATA_SHARED_USED=False
-#DATA_SHARED_DIR=/sfm-data
+DATA_SHARED_USED=True
+DATA_SHARED_DIR=/sfm-data
 
 # Data free space thresholds to send notification emails. Values should only end with MB,GB,TB. eg. 500MB,10GB,1TB
 # Use DATA_THRESHOLD_SHARED when all data volumes are on the same filesystem and DATA_SHARED_USED is True.
-#DATA_THRESHOLD_SHARED=6GB
+DATA_THRESHOLD_SHARED=10GB
 DATA_VOLUME_THRESHOLD_DB=10GB
 DATA_VOLUME_THRESHOLD_MQ=10GB
 DATA_VOLUME_THRESHOLD_EXPORT=10GB

--- a/example.env
+++ b/example.env
@@ -11,11 +11,13 @@ COMPOSE_PROJECT_NAME=sfm
 
 # VOLUME CONFIGURATION
 # Volumes come in 2 types: normal Docker volumes (e.g., /sfm-mq-data)
-# or host volumes (which link to an external location; e.g., /src/sfm-mq-data:/sfm-mq-data).
+# or host volumes (which link to an external location; e.g., /sfm-data/sfm-mq-data:/sfm-mq-data).
 # A config example to use a docker volume: DATA_VOLUME_MQ=/sfm-mq-data
-# A config example to use an external location: DATA_VOLUME_MQ=/mnt/external-mq:/sfm-mq-data
-# An internal volume should be adequate for development; for production,
-# you probably want to use a link to an external location.
+# A config example to use an external location: DATA_VOLUME_MQ=/sfm-data/sfm-mq-data:/sfm-mq-data
+# A docker "internal" volume should be adequate for development; for production,
+# it is important to use an external location so that data is not lost. External locations can be a mounted 
+# folder, allowing you to store sensitive data in locations other than the server where SFM is installed.
+# We recommend creating a top-level directory for sfm data directories, e.g. /sfm-data
 # Note that the external location should be created before SFM is brought up.
 # The data volume is where:
 # * all of harvested social media content is stored (internally used /sfm-collection-set-data, /sfm-containers-data, /sfm-export-data).
@@ -26,27 +28,29 @@ COMPOSE_PROJECT_NAME=sfm
 # DATA_VOLUME_FORMER_EXPORT=/sfm-data/export:/sfm-data/export
 
 # The MQ container uses its own local volume. Configure an external location for production.
-DATA_VOLUME_MQ=/sfm-mq-data
-
-# In the case a local database is used, its data is stored under the following docker volume
-# In case a remote database is used this could point to a mounted folder where the DB stores its data,
-# otherwise it will not be used. Configure an external location for production.
-DATA_VOLUME_DB=/sfm-db-data
-
-# Sensitive export data can be stored locally or remotely on a server mounted using sshfs
-DATA_VOLUME_EXPORT=/mnt/my-ssh-drive:/sfm-export-data
-
-# Possibly sensitive data from harvesting containers can be stored remotely on a server mounted using sshfs
-DATA_VOLUME_CONTAINERS=/mnt/my-ssh-drive:/sfm-containers-data
-
-# Sensitive data about collection sets can be stored remotely on a server mounted using sshfs.
-# Configure an external location for production.
-DATA_VOLUME_COLLECTION_SET=/mnt/my-ssh-drive:/sfm-collection-set-data
+# DATA_VOLUME_MQ=/sfm-mq-data
+DATA_VOLUME_MQ=/sfm-data/sfm-mq-data:/sfm-mq-data
+# In the case a local database is used for development, its data is stored in a docker volume.
+# Configure an external location for production. The external location can be also be a remote database mounted from elsewhere. 
+# DATA_VOLUME_DB=/sfm-db-data
+DATA_VOLUME_DB=/sfm-data/sfm-db-data:/sfm-db-data
+# Sensitive export data can be stored locally or on the server, optionally a remote server mounted using sshfs
+# DATA_VOLUME_EXPORT=/sfm-export-data
+# DATA_VOLUME_EXPORT=/mnt/my-ssh-drive:/sfm-export-data
+DATA_VOLUME_EXPORT=/sfm-data/sfm-export-data:/sfm-export-data
+# Data about containers can be stored locally or on the server, optionally a remote server mounted using sshfs
+# DATA_VOLUME_CONTAINERS=/sfm-containers-data
+# DATA_VOLUME_CONTAINERS=/mnt/my-ssh-drive:/sfm-containers-data
+DATA_VOLUME_CONTAINERS=/sfm-data/sfm-containers-data:/sfm-containers-data
+# Data about collection sets, including WARCs, can be stored locally or on the server, optionally a remote server mounted using sshfs.
+# DATA_VOLUME_COLLECTION_SET=/sfm-collection-set-data
+# DATA_VOLUME_COLLECTION_SET=/mnt/my-ssh-drive:/sfm-collection-set-data
+DATA_VOLUME_COLLECTION_SET=/sfm-data/sfm-collection-set-data:/sfm-collection-set-data
 
 # The processing volume is where processed data is stored when using a processing
-# container. Use processing.docker-compose.yml to start a processing container.
-PROCESSING_VOLUME=/sfm-processing
-#PROCESSING_VOLUME=/src/sfm-processing:/sfm-processing
+# container. This should usually be an external location. Use processing.docker-compose.yml to start a processing container.
+# PROCESSING_VOLUME=/sfm-processing
+PROCESSING_VOLUME=/sfm-data/sfm-processing:/sfm-processing
 
 # If all data volumes (does not include /sfm-processing) are on the same filesystem 
 # DATA_SHARED_USED should be True and provide DATA_SHARED_DIR, which is used only for calculating space usage.

--- a/example.env
+++ b/example.env
@@ -43,7 +43,15 @@ DATA_VOLUME_COLLECTION_SET=/mnt/my-ssh-drive:/sfm-collection-set-data
 PROCESSING_VOLUME=/sfm-processing
 #PROCESSING_VOLUME=/src/sfm-processing:/sfm-processing
 
+# If all data volumes are on the same filesystem (the default configuration before SFM 2.4.0) 
+# set DATA_SHARED_USED to True and uncomment and provide DATA_SHARED_DIR, which is used only for calculating space usage.
+# The value of DATA_SHARED_DIR is the parent directory for data volumes, e.g. /sfm-data
+DATA_SHARED_USED=False
+#DATA_SHARED_DIR=/sfm-data
+
 # Data free space thresholds to send notification emails. Values should only end with MB,GB,TB. eg. 500MB,10GB,1TB
+# Use DATA_THRESHOLD_SHARED when all data volumes are on the same filesystem and DATA_SHARED_USED is True.
+#DATA_THRESHOLD_SHARED=6GB
 DATA_VOLUME_THRESHOLD_DB=10GB
 DATA_VOLUME_THRESHOLD_MQ=10GB
 DATA_VOLUME_THRESHOLD_EXPORT=10GB

--- a/example.env
+++ b/example.env
@@ -20,8 +20,12 @@ COMPOSE_PROJECT_NAME=sfm
 # The data volume is where:
 # * all of harvested social media content is stored (internally used /sfm-collection-set-data, /sfm-containers-data, /sfm-export-data).
 # * the db files are located (internally used /sfm-db-data).
+# If you ran SFM version 2.3.0 or earlier, SFM needs to find collection sets and exports using
+# the previous directory structure. Uncomment and make sure the external locations match where data is stored.
+# DATA_VOLUME_FORMER_COLLECTION_SET=/sfm-data/collection_set:/sfm-data/collection_set
+# DATA_VOLUME_FORMER_EXPORT=/sfm-data/export:/sfm-data/export
 
-# Tthe MQ container uses its own local volume. Configure an external location for production.
+# The MQ container uses its own local volume. Configure an external location for production.
 DATA_VOLUME_MQ=/sfm-mq-data
 
 # In the case a local database is used, its data is stored under the following docker volume

--- a/example.env
+++ b/example.env
@@ -24,27 +24,32 @@ COMPOSE_PROJECT_NAME=sfm
 # the MQ container uses its own local volume
 DATA_VOLUME_MQ=/sfm-mq-data
 
-# In case a local database is used, its data is stored under the following docker volume
+# In the case a local database is used, its data is stored under the following docker volume
 # In case a remote database is used this could point to a mounted folder where the DB stores its data,
 # otherwise it will not be used
 DATA_VOLUME_DB=/sfm-db-data
 
-# sensitive export data stored remoteley on a server mounted using sshfs
+# sensitive export data can be stored locally or remotely on a server mounted using sshfs
 DATA_VOLUME_EXPORT=/mnt/my-ssh-drive:/sfm-export-data
 
-# possibly sensitive data of harvesting containers stored remoteley on a server mounted using sshfs
+# possibly sensitive data from harvesting containers can be stored remotely on a server mounted using sshfs
 DATA_VOLUME_CONTAINERS=/mnt/my-ssh-drive:/sfm-containers-data
 
-# sensitive data about collection sets stored remoteley on a server mounted using sshfs
+# sensitive data about collection sets can be stored remotely on a server mounted using sshfs
 DATA_VOLUME_COLLECTION_SET=/mnt/my-ssh-drive:/sfm-collection-set-data
 
-
 # The processing volume is where processed data is stored when using a processing
-# container. Use porcessing.docker-compose.yml to start a processing container.
+# container. Use processing.docker-compose.yml to start a processing container.
 PROCESSING_VOLUME=/sfm-processing
 #PROCESSING_VOLUME=/src/sfm-processing:/sfm-processing
-# sfm-data free space threshold to send notification emails,only ends with MB,GB,TB. eg. 500MB,10GB,1TB
-DATA_VOLUME_THRESHOLD=10GB
+
+# Data free space thresholds to send notification emails. Values should only end with MB,GB,TB. eg. 500MB,10GB,1TB
+DATA_VOLUME_THRESHOLD_DB=10GB
+DATA_VOLUME_THRESHOLD_MQ=10GB
+DATA_VOLUME_THRESHOLD_EXPORT=10GB
+DATA_VOLUME_THRESHOLD_CONTAINERS=10GB
+DATA_VOLUME_THRESHOLD_COLLECTION_SET=10GB
+
 # sfm-processing free space threshold to send notification emails,only ends with MB,GB,TB. eg. 500MB,10GB,1TB
 PROCESSING_VOLUME_THRESHOLD=10GB
 # Group id for sfm group

--- a/example.env
+++ b/example.env
@@ -10,16 +10,35 @@ COMPOSE_PROJECT_NAME=sfm
 
 
 # VOLUME CONFIGURATION
-# Volumes come in 2 types: normal Docker volumes (e.g., /sfm-data)
-# or host volumes (which link to an external location; e.g., /src/sfm-data:/sfm-data).
+# Volumes come in 2 types: normal Docker volumes (e.g., /sfm-mq-data)
+# or host volumes (which link to an external location; e.g., /src/sfm-mq-data:/sfm-mq-data).
+# A config example to use a docker volume: DATA_VOLUME_MQ=/sfm-mq-data
+# A config example to use an external location: DATA_VOLUME_MQ=/mnt/external-mq:/sfm-mq-data
 # An internal volume should be adequate for development; for production,
 # you probably want to use a link to an external location.
 # Note that the external location should be created before SFM is brought up.
 # The data volume is where:
-# * all of harvested social media content is stored.
-# * the db files are located.
-DATA_VOLUME=/sfm-data
-#DATA_VOLUME=/src/sfm-data:/sfm-data
+# * all of harvested social media content is stored (internally used /sfm-collection-set-data, /sfm-containers-data, /sfm-export-data).
+# * the db files are located (internally used /sfm-db-data).
+
+# the MQ container uses its own local volume
+DATA_VOLUME_MQ=/sfm-mq-data
+
+# In case a local database is used, its data is stored under the following docker volume
+# In case a remote database is used this could point to a mounted folder where the DB stores its data,
+# otherwise it will not be used
+DATA_VOLUME_DB=/sfm-db-data
+
+# sensitive export data stored remoteley on a server mounted using sshfs
+DATA_VOLUME_EXPORT=/mnt/my-ssh-drive:/sfm-export-data
+
+# possibly sensitive data of harvesting containers stored remoteley on a server mounted using sshfs
+DATA_VOLUME_CONTAINERS=/mnt/my-ssh-drive:/sfm-containers-data
+
+# sensitive data about collection sets stored remoteley on a server mounted using sshfs
+DATA_VOLUME_COLLECTION_SET=/mnt/my-ssh-drive:/sfm-collection-set-data
+
+
 # The processing volume is where processed data is stored when using a processing
 # container. Use porcessing.docker-compose.yml to start a processing container.
 PROCESSING_VOLUME=/sfm-processing

--- a/example.prod.docker-compose.yml
+++ b/example.prod.docker-compose.yml
@@ -40,6 +40,9 @@ services:
              - ${DATA_VOLUME_EXPORT}
              - ${DATA_VOLUME_CONTAINERS}
              - ${DATA_VOLUME_COLLECTION_SET}
+             # For SFM instances installed on 2.3.0 or earlier
+             # - ${DATA_VOLUME_FORMER_COLLECTION_SET
+             # - ${DATA_VOLUME_FORMER_EXPORT}
         environment:
             - TZ
             - SFM_UID

--- a/example.prod.docker-compose.yml
+++ b/example.prod.docker-compose.yml
@@ -35,7 +35,11 @@ services:
     data:
         image: gwul/sfm-data:2.3.0
         volumes:
-             - ${DATA_VOLUME}
+             - ${DATA_VOLUME_MQ}
+             - ${DATA_VOLUME_DB}
+             - ${DATA_VOLUME_EXPORT}
+             - ${DATA_VOLUME_CONTAINERS}
+             - ${DATA_VOLUME_COLLECTION_SET}
         environment:
             - TZ
             - SFM_UID

--- a/example.prod.docker-compose.yml
+++ b/example.prod.docker-compose.yml
@@ -41,7 +41,7 @@ services:
              - ${DATA_VOLUME_CONTAINERS}
              - ${DATA_VOLUME_COLLECTION_SET}
              # For SFM instances installed on 2.3.0 or earlier
-             # - ${DATA_VOLUME_FORMER_COLLECTION_SET
+             # - ${DATA_VOLUME_FORMER_COLLECTION_SET}
              # - ${DATA_VOLUME_FORMER_EXPORT}
         environment:
             - TZ

--- a/example.prod.docker-compose.yml
+++ b/example.prod.docker-compose.yml
@@ -3,7 +3,7 @@ services:
     db:
         image: gwul/sfm-ui-db:2.3.0
         environment:
-            - SFM_POSTGRES_PASSWORD
+            - POSTGRES_PASSWORD=${SFM_POSTGRES_PASSWORD}
             - TZ
         logging:
             driver: json-file
@@ -18,7 +18,7 @@ services:
         hostname: mq
         ports:
             # Opens up the ports for RabbitMQ management
-            - "${RABBITMQ_MANAGEMENT_PORT}:15672"
+            - "${SFM_RABBITMQ_MANAGEMENT_PORT}:15672"
         environment:
             - RABBITMQ_DEFAULT_USER=${SFM_RABBITMQ_USER}
             - RABBITMQ_DEFAULT_PASS=${SFM_RABBITMQ_PASSWORD}

--- a/example.prod.docker-compose.yml
+++ b/example.prod.docker-compose.yml
@@ -94,7 +94,11 @@ services:
             # To have some test accounts created.
             - LOAD_FIXTURES=False
             - SFM_REQS=release
-            - DATA_VOLUME_THRESHOLD
+            - DATA_VOLUME_THRESHOLD_DB
+            - DATA_VOLUME_THRESHOLD_MQ
+            - DATA_VOLUME_THRESHOLD_EXPORT
+            - DATA_VOLUME_THRESHOLD_CONTAINERS
+            - DATA_VOLUME_THRESHOLD_COLLECTION_SET
             - PROCESSING_VOLUME_THRESHOLD
             - SFM_UID
             - SFM_GID

--- a/example.prod.docker-compose.yml
+++ b/example.prod.docker-compose.yml
@@ -127,9 +127,9 @@ services:
         volumes_from:
             - data
             - processingdata
-#      Uncomment to use DATA_SHARED_DIR and monitor space usage when data on single filesystem
-#        volumes:
-#            - "${DATA_SHARED_DIR}:/sfm-data-shared"
+#       # Comment out volumes section if SFM data is stored on mounted filesystems and DATA_SHARED_USED is False.
+        volumes:
+            - "${DATA_SHARED_DIR}:/sfm-data-shared"
         restart: always
 #    # For running SFM with HTTPS
 #    # When using this, in .env, SFM_PORT must be 8080 and USE_HTTPS must be True.

--- a/example.prod.docker-compose.yml
+++ b/example.prod.docker-compose.yml
@@ -100,6 +100,9 @@ services:
             - DATA_VOLUME_THRESHOLD_CONTAINERS
             - DATA_VOLUME_THRESHOLD_COLLECTION_SET
             - PROCESSING_VOLUME_THRESHOLD
+            - DATA_SHARED_USED
+            - DATA_SHARED_DIR
+            - DATA_THRESHOLD_SHARED
             - SFM_UID
             - SFM_GID
             - SFM_INSTITUTION_NAME
@@ -124,6 +127,9 @@ services:
         volumes_from:
             - data
             - processingdata
+#      Uncomment to use DATA_SHARED_DIR and monitor space usage when data on single filesystem
+#        volumes:
+#            - "${DATA_SHARED_DIR}:/sfm-data-shared"
         restart: always
 #    # For running SFM with HTTPS
 #    # When using this, in .env, SFM_PORT must be 8080 and USE_HTTPS must be True.


### PR DESCRIPTION
Based on @SvenLieber's work in #28 to configure data volumes on mounted filesystems. For space monitoring and notifications, defaults to the conventional SFM configuration with data volumes on the same filesystem. To test this PR, in addition to checking out this branch and updating `docker-compose.yml` and `.env`, check out the corresponding PRs in other repos:

* https://github.com/gwu-libraries/sfm-ui/pull/1067
* https://github.com/gwu-libraries/sfm-utils/pull/44
* https://github.com/gwu-libraries/sfm-twitter-harvester/pull/52
* https://github.com/gwu-libraries/sfm-flickr-harvester/pull/23
* https://github.com/gwu-libraries/sfm-weibo-harvester/pull/37
* https://github.com/gwu-libraries/sfm-tumblr-harvester/pull/19