### PR TITLE
Updates processing container dependencies. Fixes #1070.

### DIFF
--- a/Dockerfile-processing
+++ b/Dockerfile-processing
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 MAINTAINER Social Feed Manager <sfm@gwu.edu>
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -12,21 +12,21 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN ln -s /usr/bin/pip3 /usr/bin/pip
 
 #Upgrade pip
-RUN pip install pip==9.0.1
+RUN pip install --upgrade pip
 #Avoid the warning of https
 RUN pip install --upgrade ndg-httpsclient
 
 # Twitter
 RUN git clone https://github.com/gwu-libraries/sfm-twitter-harvester.git /opt/sfm-twitter-harvester
 WORKDIR /opt/sfm-twitter-harvester
-RUN git checkout 2.3.0
+RUN git checkout 2.4.0
 RUN pip install -r requirements/common.txt -r requirements/release.txt
 RUN pip install .
 
 # Flickr
 RUN git clone https://github.com/gwu-libraries/sfm-flickr-harvester.git /opt/sfm-flickr-harvester
 WORKDIR /opt/sfm-flickr-harvester
-RUN git checkout 2.3.0
+RUN git checkout 2.4.0
 RUN pip install -r requirements/common.txt -r requirements/release.txt
 RUN pip install .
 
@@ -47,6 +47,7 @@ RUN pip install .
 # Clone twarc so that have utilities
 RUN git clone https://github.com/docnow/twarc.git /opt/twarc
 WORKDIR /opt/twarc
+RUN git checkout v1.12.1
 RUN pip install -r requirements/python3.txt
 RUN pip install .
 
@@ -54,7 +55,7 @@ RUN pip install .
 RUN pip install warctools
 
 # Add JWAT-tools
-ADD https://bitbucket.org/nclarkekb/jwat-tools/downloads/jwat-tools-0.6.2.zip /tmp/
+ADD https://repo1.maven.org/maven2/org/jwat/jwat-tools/0.6.2/jwat-tools-0.6.2.zip /tmp/
 RUN unzip /tmp/jwat-tools-0.6.2.zip -d /tmp/
 RUN mv /tmp/jwat-tools-0.6.2 /opt/jwat-tools
 

--- a/requirements/processing_requirements.apt
+++ b/requirements/processing_requirements.apt
@@ -10,3 +10,4 @@ default-jre
 parallel
 jq
 curl
+libicu-dev


### PR DESCRIPTION
To use this branch, in `Dockerfile-processing`, change the line `git checkout 2.4.0` to`git checkout master`. I realize I could have left it at 2.3.0 since bumpversion will update it for release, but wanted to indicate the update here just in case. 