### PR TITLE
Changes to example.docker-compose.yml for stream exporter

### DIFF
--- a/example.docker-compose.yml
+++ b/example.docker-compose.yml
@@ -56,6 +56,12 @@ services:
             - TZ
     ui:
         image: gwul/sfm-ui:${UI_TAG}
+        # Comment out the image line and uncomment the following to build a local image
+        #build: 
+            #context: ../sfm-ui
+            #dockerfile: Dockerfile-runserver
+            #args:
+                #build_version: master
         ports:
             - "${SFM_PORT}:8080"
         links:
@@ -161,6 +167,11 @@ services:
 #            - "./server.key:/etc/nginx/certs/${SFM_HOSTNAME}.key"
     uiconsumer:
         image: gwul/sfm-ui-consumer:master
+        #build:
+        #    context: ../sfm-ui
+        #    dockerfile: Dockerfile-consumer
+        #    args:
+        #        build_version: master
         links:
             - db:db
             - mq:mq
@@ -200,6 +211,11 @@ services:
 # Twitter
     twitterrestharvester:
         image: gwul/sfm-twitter-rest-harvester:master
+        #build:
+        #    context: ../sfm-twitter-harvester
+        #    dockerfile: Dockerfile-rest-harvester
+        #    args:
+        #        build_version: master
         links:
             - mq:mq
         environment:
@@ -229,6 +245,11 @@ services:
 #            - "../warcprox:/opt/warcprox"
     twitterpriorityrestharvester:
         image: gwul/sfm-twitter-rest-harvester:master
+        #build:
+        #    context: ../sfm-twitter-harvester
+        #    dockerfile: Dockerfile-rest-harvester
+        #    args:
+        #        build_version: master
         links:
             - mq:mq
         environment:
@@ -258,6 +279,11 @@ services:
 #            - "../warcprox:/opt/warcprox"
     twitterstreamharvester:
         image: gwul/sfm-twitter-stream-harvester:master
+        #build:
+        #    context: ../sfm-twitter-harvester
+        #    dockerfile: Dockerfile-stream-harvester
+        #    args:
+        #        build_version: master
         links:
             - mq:mq
         environment:
@@ -286,6 +312,11 @@ services:
 #            - "../warcprox:/opt/warcprox"
     twitterrestexporter:
         image: gwul/sfm-twitter-rest-exporter:master
+        #build:
+        #    context: ../sfm-twitter-harvester
+        #    dockerfile: Dockerfile-rest-exporter
+        #    args:
+        #        build_version: master
         links:
             - mq:mq
             - ui:api
@@ -316,6 +347,8 @@ services:
         #build:
         #    context: ../sfm-twitter-harvester
         #    dockerfile: Dockerfile-rest-exporter-v2
+        #    args:
+        #        build_version: master
         links:
             - mq:mq
             - ui:api
@@ -344,6 +377,11 @@ services:
            # - "../warcprox:/opt/warcprox"
     twitterstreamexporter:
         image: gwul/sfm-twitter-stream-exporter:master
+        #build:
+        #    context: ../sfm-twitter-harvester
+        #    dockerfile: Dockerfile-stream-exporter
+        #    args:
+        #        build_version: master
         links:
             - mq:mq
             - ui:api
@@ -369,6 +407,38 @@ services:
 #            - "../sfm-twitter-harvester:/opt/sfm-twitter-harvester"
 #            - "../sfm-utils:/opt/sfm-utils"
 #            - "../warcprox:/opt/warcprox"
+    twitterstreamexporter2:
+        image: gwul/sfm-twitter-stream-exporter-v2:master
+        #build:
+        #    context: ../sfm-twitter-harvester
+        #    dockerfile: Dockerfile-stream-exporter-v2
+        #    args:
+        #        build_version: master
+        links:
+            - mq:mq
+            - ui:api
+        environment:
+            - TZ
+            - DEBUG
+            - SFM_RABBITMQ_USER
+            - SFM_RABBITMQ_PASSWORD
+            - SFM_RABBITMQ_HOST
+            - SFM_RABBITMQ_PORT
+            - SFM_REQS=${TWITTER_REQS}
+            - SFM_UID
+            - SFM_GID
+            - SFM_UPGRADE_REQS=${UPGRADE_REQS}
+        logging:
+            driver: json-file
+            options:
+                max-size: ${DOCKER_LOG_MAX_SIZE}
+                max-file: ${DOCKER_LOG_MAX_FILE}
+        volumes_from:
+            - data
+#        volumes:
+#           - "../sfm-twitter-harvester:/opt/sfm-twitter-harvester"
+#           - "../sfm-utils:/opt/sfm-utils"
+#           - "../warcprox:/opt/warcprox"
 
 # FLICKR
     flickrharvester:

--- a/example.docker-compose.yml
+++ b/example.docker-compose.yml
@@ -126,6 +126,7 @@ services:
             - SFM_WEIBO_SEARCH_OPTION
             - SFM_USE_HTTPS
             - SFM_USE_ELB
+            - TWITTER_COLLECTION_TYPES
             # For ngninx-proxy
             - VIRTUAL_HOST=${SFM_HOSTNAME}
             - VIRTUAL_PORT=${SFM_PORT}

--- a/example.env
+++ b/example.env
@@ -174,6 +174,13 @@ TUMBLR_HARVEST_TRIES=3
 WEIBO_HARVEST_TRIES=3
 FLICKR_HARVEST_TRIES=3
 
+# List of enabled collection types for the Twitter API
+# Should be comma-separated string of values; used in model.py
+# Possible values: twitter_search,twitter_filter,twitter_filter_stream,twitter_user_timeline,twitter_sample,twitter_academic_search,twitter_search_2,twitter_user_timeline_2
+# twitter_search,twitter_filter,twitter_user_timeline,twitter_sample => (deprecated) Twitter v 1.1 API 
+# twitter_academic_search,twitter_filter_stream => not available with Basic Access to Twitter v. 2 API
+TWITTER_COLLECTION_TYPES='twitter_search_2,twitter_user_timeline_2'
+
 #EXPORTER CONFIGURATION
 # MAX_DATAFRAME_ROWS is for exports from Twitter (API v. 2) harvests, using twarc_csv
 # Adjust this number to tweak performance of the exporter

--- a/example.env
+++ b/example.env
@@ -179,7 +179,7 @@ FLICKR_HARVEST_TRIES=3
 # Possible values: twitter_search,twitter_filter,twitter_filter_stream,twitter_user_timeline,twitter_sample,twitter_academic_search,twitter_search_2,twitter_user_timeline_2
 # twitter_search,twitter_filter,twitter_user_timeline,twitter_sample => (deprecated) Twitter v 1.1 API 
 # twitter_academic_search,twitter_filter_stream => not available with Basic Access to Twitter v. 2 API
-TWITTER_COLLECTION_TYPES='twitter_search_2,twitter_user_timeline_2'
+TWITTER_COLLECTION_TYPES=twitter_search_2,twitter_user_timeline_2
 
 #EXPORTER CONFIGURATION
 # MAX_DATAFRAME_ROWS is for exports from Twitter (API v. 2) harvests, using twarc_csv

--- a/example.prod.docker-compose.yml
+++ b/example.prod.docker-compose.yml
@@ -119,6 +119,7 @@ services:
             - SFM_WEIBO_SEARCH_OPTION
             - SFM_USE_HTTPS
             - SFM_USE_ELB
+            - TWITTER_COLLECTION_TYPES
             # For ngninx-proxy
             - VIRTUAL_HOST=${SFM_HOSTNAME}
             - VIRTUAL_PORT=${SFM_PORT}


### PR DESCRIPTION
### Contains
- Optional `build` sections with build argument (for building images locally)
- Stream exporter service (for Twitter v. 2 API)

### Testing
- Add changes to local `docker-compose.yml` and verify that `docker-compose up -d` starts with all services.